### PR TITLE
Change destinations to be a map instead of list, to allow it to be sp…

### DIFF
--- a/argoApps/templates/projects.yaml
+++ b/argoApps/templates/projects.yaml
@@ -24,6 +24,15 @@ spec:
       name: {{ $destvalue.name }}
       {{- end }}
   {{- end }}
+  {{- range $destname, $destvalue := $value.extraDestinations }}
+    - namespace:   {{ $destvalue.namespace }}
+      {{- if ($destvalue.server) }}
+      server:  {{ $destvalue.server }}
+      {{- end }}
+      {{- if ($destvalue.name) }}
+      name: {{ $destvalue.name }}
+      {{- end }}
+  {{- end }}
 
   {{- if ($value.clusterResourceWhitelist) }}
   clusterResourceWhitelist:

--- a/argoApps/templates/projects.yaml
+++ b/argoApps/templates/projects.yaml
@@ -15,8 +15,8 @@ spec:
     - {{ $source }}
     {{- end }}
   destinations:
-  {{- range $destnamespace, $destvalue := $value.destinations }}
-    - namespace: {{ $destnamespace }}
+  {{- range $destname, $destvalue := $value.destinations }}
+    - namespace:   {{ $destvalue.namespace }}
       {{- if ($destvalue.server) }}
       server:  {{ $destvalue.server }}
       {{- end }}

--- a/argoApps/templates/projects.yaml
+++ b/argoApps/templates/projects.yaml
@@ -15,8 +15,8 @@ spec:
     - {{ $source }}
     {{- end }}
   destinations:
-  {{- range $destname, $destvalue := $value.destinations }}
-    - namespace:   {{ $destvalue.namespace }}
+  {{- range $destnamespace, $destvalue := $value.destinations }}
+    - namespace: {{ $destnamespace }}
       {{- if ($destvalue.server) }}
       server:  {{ $destvalue.server }}
       {{- end }}


### PR DESCRIPTION
For at kunne flytte https://dev.azure.com/Fstyr/fstyr-ddp/_git/ddp-k8s?path=/deployment/apps/values.yaml i forskellige filer (alt i bundet er miljø specifikt). 
Vil også kunne bruges til f.eks. https://github.com/KvalitetsIT/kithosting-k8s/blob/test/deployment/apps/infrastructure/values.yaml hvor medcom-sdn, og medcom-sdn-demo oprettes i alle miljøer. 
Ændrer syntaks fra: 
```
      destinations:
        - namespace: infrastructure
          server: https://kubernetes.default.svc
        - namespace: argocd
          server: https://kubernetes.default.svc
```
til: 

```
      destinations:
        infrastructure:
          server: https://kubernetes.default.svc
        argocd:
          server: https://kubernetes.default.svc
```