### PR TITLE
feat: support kustomizations in Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To illustrate properties inside objects in lists, an `[]` is added to show that 
 ### Common
 Theese properties are both used in projects and applications - And should always be filed
 
-| Value                                 | Description                                         | Valuetype         |  
+| Value                                 | Description                                         | Valuetype         |
 | -----                                 | -----------                                         | -----------       |
 | `server`                              | server for allowed destinations                     | `<string>`        |
 | `namespaceArgo`                       | What namespace to create the entities               | `<string>`        |
@@ -61,7 +61,7 @@ Theese properties are both used in projects and applications - And should always
 
 ### Argo applications
 
-| Value                                 | Description                                                             | Valuetype         |  
+| Value                                 | Description                                                             | Valuetype         |
 | -----                                 | -----------                                                             | -----------       |
 | `repoUrl`                             | Gitrepo the application should be created from                          | `<git-repo-url>`  |
 | `namespace`                           | Default namespace for destination                                       | `<string>`        |
@@ -69,6 +69,7 @@ Theese properties are both used in projects and applications - And should always
 | `applications`                        | List containing applications to create                                  | `<list<obj>>`     |
 | `applications[].namespace`            | Namespace for destination                                               | `<string>`        |
 | `applications[].valueFiles`           | List with values-files to use for application                           | `<string>`        |
+| `applications[].kustomize`            | If set to `true` or an object, the application is deployed as a Kustomize app. If an object is provided, it will be used as Kustomize options. | `<bool>` or `<obj>` |
 | `applications[].path`                 | path from root to application-folder                                    | `<string>`        |
 | `applications[].targetRevision`       | What branch should be used                                              | `<string>`        |
 | `applications[].sync`                 | If `true` an `automated` syncPolicy is added - Argo will sync automatically | `<bool>`        |

--- a/argoApps/templates/applications.yaml
+++ b/argoApps/templates/applications.yaml
@@ -28,12 +28,16 @@ spec:
     {{- end }}
   project: {{ $value.project | default $project }}
   source:
-    {{- if not $value.valueFiles }}
+    {{- if kindIs "map" $value.kustomize }}
+    kustomize:
+      {{- toYaml $value.kustomize | nindent 6 }}
+    {{- else if eq $value.kustomize true }}
+    kustomize: {}
+    {{- else if not $value.valueFiles }}
     directory:
       recurse: true
       jsonnet: {}
-    {{- end }}
-    {{- if $value.valueFiles }}
+    {{- else }}
     helm:
       valueFiles:
         {{- range $file := $value.valueFiles }}

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -15,7 +15,7 @@ projects:
     orphanedResources:
       disable: true
 applications:
-  
+
   simplest-app:
     path: deployment/apps/infrastructure
     targetRevision: prod
@@ -28,7 +28,7 @@ applications:
       - values.yaml
       - values-test.yaml
     namespace: infrastructure
-  
+
   with-auto-sync:
     path: deployment/apps/infrastructure
     targetRevision: prod
@@ -37,3 +37,18 @@ applications:
       auto: true
       prune: true
       selfHeal: true
+
+  kustomize-with-options:
+    path: deployment/apps/kustomize-app
+    targetRevision: prod
+    kustomize:
+      namePrefix: kustomize-
+      commonLabels:
+        app.kubernetes.io/
+    namespace: infrastructure
+
+  kustomize-without-options:
+    path: deployment/apps/kustomize-app
+    targetRevision: prod
+    kustomize: true
+    namespace: infrastructure


### PR DESCRIPTION
This PR updates the `application.yaml` template to support cases where we only want to apply kustomization files. Since in those cases it we don't wanna have the `directory` or the `helm` blocks.

I have made support for setting `kustomize` in the applications, it can either be `true` or an object with more options.