### PR TITLE
feat: add prunePropagationPolicy support to syncOptions

### DIFF
--- a/argoApps/templates/applicationSet.yaml
+++ b/argoApps/templates/applicationSet.yaml
@@ -53,7 +53,7 @@ spec:
           prune: {{ $value.sync.prune | default true}}
           selfHeal: {{ $value.sync.selfHeal | default true}}
       {{- end}}
-      {{- if or ($value.createNamespace) ($value.serverSideApply) }}
+      {{- if or ($value.createNamespace) ($value.serverSideApply) ($value.prunePropagationPolicy) }}
         syncOptions:
       {{- end }}
       {{- if $value.createNamespace }}
@@ -61,6 +61,9 @@ spec:
       {{- end}}
       {{- if $value.serverSideApply }}
           - ServerSideApply=true
+      {{- end}}
+      {{- if $value.prunePropagationPolicy }}
+          - PrunePropagationPolicy={{ $value.prunePropagationPolicy }}
       {{- end}}
       {{- end}}
       {{- if ($value.ignoreDifferences)}}

--- a/argoApps/templates/applications.yaml
+++ b/argoApps/templates/applications.yaml
@@ -58,6 +58,9 @@ spec:
       - FailOnSharedResource={{ $value.failOnSharedResource | default true }}
       - CreateNamespace={{ $value.createNamespace | default false }}
       - ServerSideApply={{ $value.serverSideApply | default false }}
+      {{- if $value.prunePropagationPolicy }}
+      - PrunePropagationPolicy={{ $value.prunePropagationPolicy }}
+      {{- end }}
   {{- if ($value.ignoreDifferences) }}
   ignoreDifferences:
     {{- toYaml $value.ignoreDifferences | nindent 4 }}

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -37,3 +37,11 @@ applications:
       auto: true
       prune: true
       selfHeal: true
+
+  with-background-prune:
+    path: deployment/apps/infrastructure
+    targetRevision: prod
+    namespace: infrastructure
+    sync:
+      auto: true
+    prunePropagationPolicy: background


### PR DESCRIPTION
## What

Allow consumers to configure the Kubernetes garbage collection propagation
policy for pruned resources via a new `prunePropagationPolicy` value in both
`applications.yaml` and `applicationSet.yaml`.

**Usage:**
```yaml
applications:
  my-app:
    path: deployment/my-app
    targetRevision: main
    sync:
      auto: true
    prunePropagationPolicy: background
```

## Why

Without this, ArgoCD defaults to `foreground` deletion when pruning resources.
Foreground deletion adds a finalizer to the owner resource (e.g. a migration
Job), which keeps it visible in the Kubernetes API until all dependents (Pods)
are fully removed. During bulk/mass deployments this causes the ArgoCD
reconciler to repeatedly see lingering resources and mark applications
OutOfSync.

Setting `prunePropagationPolicy: background` removes the owner resource from
the API immediately and lets the garbage collector clean up dependents
asynchronously — matching standard `kubectl delete` behaviour and eliminating
the reconciler confusion.

## Behaviour

- The value is **optional and omitted by default**, preserving existing
  behaviour for all current consumers.
- Accepts any valid Kubernetes propagation policy: `background`, `foreground`,
  or `orphan`.
- In `applicationSet.yaml` the `syncOptions` block condition is extended to
  also render when `prunePropagationPolicy` is set.

## Risk

Low. The change is additive and opt-in. No existing consumers are affected
unless they explicitly set the new value.